### PR TITLE
Add LaTeX template for Binance data

### DIFF
--- a/binance_data.tex
+++ b/binance_data.tex
@@ -1,0 +1,15 @@
+\documentclass{article}
+\usepackage{csvsimple}
+\usepackage{booktabs}
+\begin{document}
+
+% Binance data table
+\csvreader[
+    table head=\toprule Time & Open & High & Low & Close\\\midrule,
+    late after line=\\,
+    table foot=\bottomrule,
+    respect all,
+]{binance_data.csv}{timestamp=\Time,open=\Open,high=\High,low=\Low,close=\Close}%
+{\Time & \Open & \High & \Low & \Close}
+
+\end{document}


### PR DESCRIPTION
## Summary
- add `binance_data.tex` containing a LaTeX template for reading Binance CSV data using `csvsimple`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6845b3eca3948323a1b4cc3c662ce672